### PR TITLE
Do not render slides before receiving start event

### DIFF
--- a/src/rise-slides.js
+++ b/src/rise-slides.js
@@ -40,8 +40,14 @@ export default class RiseSlides extends PolymerElement {
     return "configured";
   }
 
+  static get EVENT_START() {
+    return "start";
+  }
+  
   constructor() {
     super();
+
+    this._started = false;
   }
 
   ready() {
@@ -55,12 +61,13 @@ export default class RiseSlides extends PolymerElement {
   }
 
   _init() {
+    this.addEventListener(RiseSlides.EVENT_START, this._handleStart, {once: true});
     this._sendEvent(RiseSlides.EVENT_CONFIGURED);
   }
 
   _computeUrl(src, duration) {
 
-    if (!src) {
+    if (!this._started || !src) {
       return undefined;
     }
 
@@ -75,6 +82,17 @@ export default class RiseSlides extends PolymerElement {
     return url.href;
   }
 
+  _handleStart() {
+
+    let savedSrc = this.src;
+
+    //re-assign "src" in order to trigger "url" re-evaluation
+    this.src = undefined;
+    this._started = true;
+    this.src = savedSrc;
+    
+  }
+
   _sendEvent(eventName, detail = {}) {
     const event = new CustomEvent(eventName, {
       bubbles: true, composed: true, detail
@@ -85,4 +103,3 @@ export default class RiseSlides extends PolymerElement {
 }
 
 customElements.define("rise-slides", RiseSlides);
-

--- a/src/rise-slides.js
+++ b/src/rise-slides.js
@@ -67,7 +67,7 @@ export default class RiseSlides extends PolymerElement {
   _computeUrl(src, duration, _started) {
 
     if (!_started || !src) {
-      return undefined;
+      return "";
     }
 
     const url = new URL(src);

--- a/src/rise-slides.js
+++ b/src/rise-slides.js
@@ -30,7 +30,7 @@ export default class RiseSlides extends PolymerElement {
       },
       url: {
         type: String,
-        computed: "_computeUrl(src, duration)"
+        computed: "_computeUrl(src, duration, _started)"
       }
     }
   }
@@ -43,10 +43,9 @@ export default class RiseSlides extends PolymerElement {
   static get EVENT_START() {
     return "start";
   }
-  
+
   constructor() {
     super();
-
     this._started = false;
   }
 
@@ -65,9 +64,9 @@ export default class RiseSlides extends PolymerElement {
     this._sendEvent(RiseSlides.EVENT_CONFIGURED);
   }
 
-  _computeUrl(src, duration) {
+  _computeUrl(src, duration, _started) {
 
-    if (!this._started || !src) {
+    if (!_started || !src) {
       return undefined;
     }
 
@@ -83,14 +82,7 @@ export default class RiseSlides extends PolymerElement {
   }
 
   _handleStart() {
-
-    let savedSrc = this.src;
-
-    //re-assign "src" in order to trigger "url" re-evaluation
-    this.src = undefined;
     this._started = true;
-    this.src = savedSrc;
-    
   }
 
   _sendEvent(eventName, detail = {}) {

--- a/test/rise-slides-test.html
+++ b/test/rise-slides-test.html
@@ -79,7 +79,7 @@
         test('should accept empty src', () => {
           const element = fixture('EmptySrcTestFixture');
 
-          assert.equal(element.url, undefined);
+          assert.equal(element.url, "");
         });
 
       });

--- a/test/rise-slides-test.html
+++ b/test/rise-slides-test.html
@@ -47,6 +47,8 @@
 
         test('should set embed url with parameters', () => {
           const element = fixture('StaticValueTestFixture');
+          element._handleStart();
+
           assert.equal(element.url, 'https://docs.google.com/presentation/d/e/2PACX-1vRK9noBs7XGTp-jRNkkxSR_bvTIPFq415ff2EKZIpUAOQJcYoV42XtxPGnGEd6bvjl36yZvjcn_eYDS/embed?rm=minimal&loop=true&start=true&delayms=3000');
         });
 
@@ -71,6 +73,7 @@
 
         test('should set default 10 seconds duration', () => {
           const element = fixture('DefaultDurationValueTestFixture');
+          element._handleStart();
 
           assert.equal(element.duration, 10);
           assert.equal(element.url, 'https://docs.google.com/presentation/d/e/2PACX-1vRK9noBs7XGTp-jRNkkxSR_bvTIPFq415ff2EKZIpUAOQJcYoV42XtxPGnGEd6bvjl36yZvjcn_eYDS/embed?rm=minimal&loop=true&start=true&delayms=10000');
@@ -80,6 +83,16 @@
           const element = fixture('EmptySrcTestFixture');
 
           assert.equal(element.url, "");
+        });
+
+        test('should handle "start" event', () => {
+          const element = fixture('StaticValueTestFixture');
+
+          assert.equal(element._started, false);
+
+          element.dispatchEvent(new Event('start'));
+
+          assert.equal(element._started, true);
         });
 
       });


### PR DESCRIPTION
@andrecardoso please review. Without this change player shows default slides first and then user slides. With this change it doesn't happen.