### PR TITLE
Force URL reload when property is computed

### DIFF
--- a/src/rise-slides.js
+++ b/src/rise-slides.js
@@ -87,6 +87,7 @@ export default class RiseSlides extends LoggerMixin(PolymerElement) {
     url.searchParams.set("loop", "true");
     url.searchParams.set("start", "true");
     url.searchParams.set("delayms", duration * 1000);
+    url.searchParams.set("ts", new Date().getTime());
     url.pathname = url.pathname.replace("/pub", "/embed");
 
     return url.href;

--- a/test/rise-slides-test.html
+++ b/test/rise-slides-test.html
@@ -50,7 +50,14 @@
           const element = fixture('StaticValueTestFixture');
           element._handleStart();
 
-          assert.equal(element.url, 'https://docs.google.com/presentation/d/e/2PACX-1vRK9noBs7XGTp-jRNkkxSR_bvTIPFq415ff2EKZIpUAOQJcYoV42XtxPGnGEd6bvjl36yZvjcn_eYDS/embed?rm=minimal&loop=true&start=true&delayms=3000');
+          const url = new URL(element.url);
+
+          assert.equal(url.searchParams.get("rm"), "minimal");
+          assert.equal(url.searchParams.get("loop"), "true");
+          assert.equal(url.searchParams.get("start"), "true");
+          assert.equal(url.searchParams.get("delayms"), 3000);
+          assert.isNotEmpty(url.searchParams.get("ts"));
+          assert.include(url.pathname, "/embed");
         });
 
         test('should send "configured" event when "ready" is called', (done) => {
@@ -103,7 +110,9 @@
           element._handleStart();
 
           assert.equal(element.duration, 10);
-          assert.equal(element.url, 'https://docs.google.com/presentation/d/e/2PACX-1vRK9noBs7XGTp-jRNkkxSR_bvTIPFq415ff2EKZIpUAOQJcYoV42XtxPGnGEd6bvjl36yZvjcn_eYDS/embed?rm=minimal&loop=true&start=true&delayms=10000');
+
+          const url = new URL(element.url);
+          assert.equal(url.searchParams.get("delayms"), 10000);
         });
 
         test('should accept empty src', () => {


### PR DESCRIPTION
- Add harmless "ts" parameter with the current time value to the computed URL so that it forces the object tag to reload