### PR TITLE
Render blank page when src is empty

### DIFF
--- a/src/rise-slides.js
+++ b/src/rise-slides.js
@@ -78,7 +78,7 @@ export default class RiseSlides extends LoggerMixin(PolymerElement) {
   _computeUrl(src, duration, _started) {
 
     if (!_started || !src) {
-      return "";
+      return "about:blank";
     }
 
     const url = new URL(src);

--- a/test/rise-slides-test.html
+++ b/test/rise-slides-test.html
@@ -105,6 +105,16 @@
           assert.equal(true, computedNewUrl);
         });
 
+        test('should load blank url when src is cleared', () => {
+          const element = fixture('StaticValueTestFixture');
+          const object = element.shadowRoot.children[0];
+
+          element._handleStart();
+
+          element.src = "";
+          assert.equal(object.data, "about:blank");
+        });
+
         test('should set default 10 seconds duration', () => {
           const element = fixture('DefaultDurationValueTestFixture');
           element._handleStart();
@@ -118,7 +128,7 @@
         test('should accept empty src', () => {
           const element = fixture('EmptySrcTestFixture');
 
-          assert.equal(element.url, "");
+          assert.equal(element.url, "about:blank");
         });
 
         test('should handle "start" event', () => {


### PR DESCRIPTION
- Fixes a problem where previous html content keeps showing after src is cleared