### PR TITLE
Set version for logger config

### DIFF
--- a/src/rise-slides.js
+++ b/src/rise-slides.js
@@ -1,6 +1,7 @@
 import "url-polyfill";
 import { html } from "@polymer/polymer";
 import { RiseElement } from "rise-common-component/src/rise-element.js";
+import { version } from "./rise-slides-version.js";
 
 export default class RiseSlides extends RiseElement {
 
@@ -40,6 +41,9 @@ export default class RiseSlides extends RiseElement {
 
   constructor() {
     super();
+
+    this._setVersion( version );
+
     this._started = false;
     this._loadTimerMillis = 10000;
   }


### PR DESCRIPTION
Missed this in the previous commit. Logger requires the `version` to be configured by the component.

@ezequielc @olegrise @andrecardoso please review. Thanks!